### PR TITLE
Derusa hai reveal conflict fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
    - particfularly -> particularly
 - Added the territories of the CSSF. They are accessible through a wormhole somewhere in the Illumina Regions. Find it yourself.
 - Merged `outer pelitol cluster.txt` into `pelitol cluster.txt`. Now they're all one big file.
+- Prevent Hai Reveal systems from overlapping with the route between the Illumina Regions and the northern pirate colonies, by moving Sparikau, Derusa, Kilooew, and Vamiru out of the way and replacing them with a wormhole.
 
 ### v0.10.14
 - Added the SPA Scan Blocker to block scans. Great for transporting nerve gas, and for hiding your secret plushie stash from the CSSF.

--- a/data/illumina rework.txt
+++ b/data/illumina rework.txt
@@ -30,7 +30,7 @@ system Akore
 		period 39.77
 
 system Derusa
-	pos -893.26811 -590.62189
+	pos -1121.4444 -580.36111
 	link Kilooew
 	link Sparikau
 	object
@@ -51,7 +51,7 @@ system Derusa
 		period 170.33
 
 system Sparikau
-	pos -856.82367 -656.84411
+	pos -1154.4444 -620.36111
 	link Derusa
 	link Vamiru
 	object
@@ -72,8 +72,7 @@ system Sparikau
 		period 321.870
 
 system Vamiru
-	pos -795.04589 -705.733
-	link Luduras
+	pos -1201.4444 -670.36111
 	link Sparikau
 	object
 		sprite "star/g3"

--- a/data/map.txt
+++ b/data/map.txt
@@ -914,7 +914,7 @@ system Kiselot
 		period 35.4978
 
 system Kilooew
-	pos -929.77777 -538.13888
+	pos -1065.4444 -540.36111
 	government Pirate
 	link Eileri
 	link Derusa
@@ -1023,7 +1023,6 @@ system Ladosak
 
 system Luduras
 	pos -725.38889 -713.83333
-	link Vamiru
 	link Kiselot
 	arrival 4100
 	object

--- a/data/map.txt
+++ b/data/map.txt
@@ -360,6 +360,10 @@ system Eileri
 		sprite "planet/gas3"
 		distance 7053.1134
 		period 2048.507
+	object "Eileri-Luduras Wormhole"
+		sprite "planet/wormhole"
+		distance 9410.394
+		period 3310.493
 
 ### F
 system Finduue
@@ -1026,6 +1030,10 @@ system Luduras
 		sprite "star/m8"
 		distance 0
 		period 37.402
+	object "Eileri-Luduras Wormhole"
+		sprite "planet/wormhole"
+		distance 8156.7340
+		period 2119.178
 
 
 system Lindookor
@@ -2043,3 +2051,6 @@ planet Eisei
 #===< Wormholes >===#
 # planet "Pelitol-Sedlai Wormhole"
 # 	description ""
+
+planet "Eileri-Luduras Wormhole"
+	description ``


### PR DESCRIPTION
This PR will prevent LEEST systems from overlapping with vanilla Hai Reveal systems

# before
![image](https://user-images.githubusercontent.com/74448738/205787624-fed55373-eca3-44cf-8b16-31e4ef953ac4.png)

# after
![image](https://user-images.githubusercontent.com/74448738/205787597-c75e733e-020d-4c6b-bf05-28ae26e65861.png)
